### PR TITLE
IMPROVEMENT: Add using of local changes

### DIFF
--- a/src/Webinex.Calendar.All/Package.props
+++ b/src/Webinex.Calendar.All/Package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <Title>Webinex Calendar</Title>
-    <PackageVersion>1.1.0-rc9</PackageVersion>
+    <PackageVersion>1.1.0-rc10</PackageVersion>
     <Authors>Webinex Dev</Authors>
     <NoWarn>$(NoWarn);CS1591;CS0660;CS0661</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Webinex.Calendar.Tests.Integration/Setups/TestDbContext.cs
+++ b/src/Webinex.Calendar.Tests.Integration/Setups/TestDbContext.cs
@@ -20,10 +20,10 @@ public class TestDbContext : DbContext, ICalendarDbContext<EventData>
             row.HasKey(x => x.Id);
 
             row
-                .HasOne(x => x.RecurrentEvent)
-                .WithOne()
-                .HasForeignKey<EventRow<EventData>>(x => x.RecurrentEventId)
-                .OnDelete(DeleteBehavior.Restrict);
+                .HasOne(e => e.RecurrentEvent)
+                .WithMany()
+                .HasForeignKey(x => x.RecurrentEventId)
+                .OnDelete(DeleteBehavior.ClientCascade);
 
             row.OwnsOne(x => x.Effective, effective =>
             {

--- a/src/Webinex.Calendar/DataAccess/EventRow.cs
+++ b/src/Webinex.Calendar/DataAccess/EventRow.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
 using Webinex.Calendar.Common;
 using Webinex.Calendar.Events;
 using Webinex.Calendar.Repeats;
@@ -49,6 +50,10 @@ public class EventRow<TData>
     public bool Cancelled { get; protected set; }
     public TData Data { get; protected set; } = null!;
     public Period? MoveTo { get; protected set; }
+
+    [MemberNotNullWhen(true, nameof(RecurrentEventId))]
+    internal bool IsRecurrentEventState() => Type == EventType.RecurrentEventState;
+    
     internal EventRow<TData>? RecurrentEvent { get; set; }
 
     internal EventRowId GetEventRowId() => new EventRowId(Type, Id, RecurrentEventId, Effective.ToOpenPeriod().Start);

--- a/src/Webinex.Calendar/Filters/EventFiltersProvider.cs
+++ b/src/Webinex.Calendar/Filters/EventFiltersProvider.cs
@@ -54,20 +54,9 @@ public record EventFiltersProvider<TData>(
         if (!State)
             return null;
 
-        Expression<Func<EventRow<TData>, bool>> expression = x =>
-            x.Type == EventType.RecurrentEventState && (
-                (x.Effective.Start < To.TotalMinutesSince1990() &&
-                 x.Effective.End!.Value > From.TotalMinutesSince1990())
-                || (x.MoveTo != null && x.MoveTo.Start < To && x.MoveTo.End > From));
-
-        if (!Data || DataFilter == null)
-            return expression;
-
-        return Expressions.And(
-            expression,
-            Expressions.Or(
-                Expressions.Child<EventRow<TData>, TData>(x => x.Data, DataFilter),
-                Expressions.Child<EventRow<TData>, TData>(x => x.RecurrentEvent!.Data, DataFilter)));
+        return x => x.Type == EventType.RecurrentEventState && (
+            (x.Effective.Start < To.TotalMinutesSince1990() && x.Effective.End!.Value > From.TotalMinutesSince1990()) ||
+            (x.MoveTo != null && x.MoveTo.Start < To && x.MoveTo.End > From));
     }
 
     private Expression<Func<EventRow<TData>, bool>>? CreateRecurrentEventFilter()

--- a/src/Webinex.Calendar/IRecurrentEventCalendarInstance.cs
+++ b/src/Webinex.Calendar/IRecurrentEventCalendarInstance.cs
@@ -10,7 +10,13 @@ public interface IRecurrentEventCalendarInstance<TData>
     Task<RecurrentEvent<TData>?> GetAsync(Guid id);
     Task<RecurrentEvent<TData>[]> GetManyAsync(IEnumerable<Guid> ids);
     Task<RecurrentEvent<TData>[]> GetAllAsync(FilterRule filter);
-    Task<RecurrentEvent<TData>[]> GetManyAsync(FilterRule filter, SortRule? sortRule = null, PagingRule? pagingRule = null);
+
+    [Obsolete("Please use 'GetAllAsync' instead. This method doesn't use local changes")]
+    Task<RecurrentEvent<TData>[]> GetManyAsync(
+        FilterRule filter,
+        SortRule? sortRule = null,
+        PagingRule? pagingRule = null);
+
     Task<RecurrentEvent<TData>> AddAsync(RecurrentEvent<TData> @event);
     Task<RecurrentEvent<TData>[]> AddRangeAsync(IEnumerable<RecurrentEvent<TData>> events);
     Task MoveAsync(RecurrentEvent<TData> @event, DateTimeOffset eventStart, Period moveTo);
@@ -21,7 +27,7 @@ public interface IRecurrentEventCalendarInstance<TData>
     Task DeleteRangeAsync(IEnumerable<RecurrentEvent<TData>> events);
 
     Task<RecurrentEventState<TData>?> GetStateAsync(RecurrentEventStateId id);
-    
+
     /// <summary>
     /// Returns all event states according to filters
     /// </summary>
@@ -37,7 +43,7 @@ public interface IRecurrentEventCalendarInstance<TData>
     /// </list>
     /// </param>
     Task<RecurrentEventState<TData>[]> GetAllStatesAsync(FilterRule filter);
-    
+
     Task<RecurrentEventState<TData>[]> GetManyStatesAsync(IEnumerable<RecurrentEventStateId> ids);
     Task<Event<TData>> SaveDataAsync(RecurrentEvent<TData> @event, DateTimeOffset eventStart, TData data);
     Task<Event<TData>> AddDataAsync(RecurrentEvent<TData> @event, DateTimeOffset start, TData data);

--- a/src/Webinex.Calendar/IRecurrentEventCalendarInstance.cs
+++ b/src/Webinex.Calendar/IRecurrentEventCalendarInstance.cs
@@ -9,6 +9,7 @@ public interface IRecurrentEventCalendarInstance<TData>
 {
     Task<RecurrentEvent<TData>?> GetAsync(Guid id);
     Task<RecurrentEvent<TData>[]> GetManyAsync(IEnumerable<Guid> ids);
+    Task<RecurrentEvent<TData>[]> GetAllAsync(FilterRule filter);
     Task<RecurrentEvent<TData>[]> GetManyAsync(FilterRule filter, SortRule? sortRule = null, PagingRule? pagingRule = null);
     Task<RecurrentEvent<TData>> AddAsync(RecurrentEvent<TData> @event);
     Task<RecurrentEvent<TData>[]> AddRangeAsync(IEnumerable<RecurrentEvent<TData>> events);


### PR DESCRIPTION
Added using of local changes:
- CancelAsync
- DeleteAsync
- GetAllStatesAsync
- GetRowsFromDbContextAsync

Added new method `IRecurrentEventCalendarInstance<TData>.GetAllAsync(FilterRule filter)`. This method uses local changes under the hood as well

Removed redundant filtering by data in recurrentevent, when we filter by state