### PR TITLE
IMPROVEMENT: improved performance of weekdays filtration

### DIFF
--- a/src/Webinex.Calendar.All/Package.props
+++ b/src/Webinex.Calendar.All/Package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <Title>Webinex Calendar</Title>
-    <PackageVersion>1.1.0-rc14</PackageVersion>
+    <PackageVersion>1.1.0-rc15</PackageVersion>
     <Authors>Webinex Dev</Authors>
     <NoWarn>$(NoWarn);CS1591;CS0660;CS0661</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Webinex.Calendar/Common/Period.cs
+++ b/src/Webinex.Calendar/Common/Period.cs
@@ -30,20 +30,24 @@ public class Period : Equatable
 
     public Weekday[] FullDayWeekdays()
     {
-        var value = Start.TimeOfDay > TimeSpan.Zero
+        var start = Start.TimeOfDay > TimeSpan.Zero
             ? Start.AddDays(1).StartOfTheDay()
             : Start;
 
         var end = End.StartOfTheDay();
 
-        var weekdays = new LinkedList<Weekday>();
-        while (value < end && weekdays.Count < 7)
-        {
-            weekdays.AddLast(Weekday.From(value.DayOfWeek));
-            value = value.AddDays(1);
-        }
+        if (start >= end) return Array.Empty<Weekday>();
 
-        return weekdays.Distinct().ToArray();
+        var diffInDays = (int)(end - start).TotalDays;
+        var startWeekday = Weekday.From(start.DayOfWeek);
+
+        return diffInDays switch
+        {
+            0 => Array.Empty<Weekday>(),
+            > 0 and < 7 => Enumerable.Range(0, diffInDays).Select(i => startWeekday.Add(i)).ToArray(),
+            >= 7 => Weekday.All,
+            _ => throw new ArgumentOutOfRangeException()
+        };
     }
 
     public static bool operator ==(Period? left, Period? right)
@@ -55,6 +59,8 @@ public class Period : Equatable
     {
         return NotEqualOperator(left, right);
     }
+
+    public override string ToString() => $"{Start:s} - {End:s}";
 
     protected override IEnumerable<object?> GetEqualityComponents()
     {

--- a/src/Webinex.Calendar/Common/Weekday.cs
+++ b/src/Webinex.Calendar/Common/Weekday.cs
@@ -1,9 +1,9 @@
-﻿using NodaTime;
-
-namespace Webinex.Calendar.Common;
+﻿namespace Webinex.Calendar.Common;
 
 public class Weekday : Equatable
 {
+    public const int DAYS_IN_WEEK = 7;
+
     private static readonly Weekday[] ORDERED_VALUES =
     {
         Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday,
@@ -22,16 +22,70 @@ public class Weekday : Equatable
 
     public string Value { get; protected init; } = null!;
 
-    public static Weekday Monday => new() { Value = "Monday" };
-    public static Weekday Tuesday => new() { Value = "Tuesday" };
-    public static Weekday Wednesday => new() { Value = "Wednesday" };
-    public static Weekday Thursday => new() { Value = "Thursday" };
-    public static Weekday Friday => new() { Value = "Friday" };
-    public static Weekday Saturday => new() { Value = "Saturday" };
-    public static Weekday Sunday => new() { Value = "Sunday" };
+    private const string MONDAY = "Monday";
+    private const string TUESDAY = "Tuesday";
+    private const string WEDNESDAY = "Wednesday";
+    private const string THURSDAY = "Thursday";
+    private const string FRIDAY = "Friday";
+    private const string SATURDAY = "Saturday";
+    private const string SUNDAY = "Sunday";
+
+    public static Weekday Monday => new() { Value = MONDAY };
+    public static Weekday Tuesday => new() { Value = TUESDAY };
+    public static Weekday Wednesday => new() { Value = WEDNESDAY };
+    public static Weekday Thursday => new() { Value = THURSDAY };
+    public static Weekday Friday => new() { Value = FRIDAY };
+    public static Weekday Saturday => new() { Value = SATURDAY };
+    public static Weekday Sunday => new() { Value = SUNDAY };
 
     public static Weekday[] All => POSSIBLE_VALUES.Select(value => new Weekday { Value = value }).ToArray();
 
+    public Weekday Next() => Add(1);
+    public Weekday Previous() => Add(-1);
+
+    private int OrderIndex() => Value switch
+    {
+        MONDAY => 0,
+        TUESDAY => 1,
+        WEDNESDAY => 2,
+        THURSDAY => 3,
+        FRIDAY => 4,
+        SATURDAY => 5,
+        SUNDAY => 6,
+        _ => throw new ArgumentOutOfRangeException(),
+    };
+
+    public Weekday Add(int days)
+    {
+        var nextOrderIndex = (OrderIndex() + days) % DAYS_IN_WEEK;
+        nextOrderIndex = nextOrderIndex < 0 ? DAYS_IN_WEEK + nextOrderIndex : nextOrderIndex;
+        return ORDERED_VALUES[nextOrderIndex];
+    }
+
+    public static Weekday From(DayOfWeek dayOfWeek) => dayOfWeek switch
+    {
+        DayOfWeek.Monday => Weekday.Monday,
+        DayOfWeek.Tuesday => Weekday.Tuesday,
+        DayOfWeek.Wednesday => Weekday.Wednesday,
+        DayOfWeek.Thursday => Weekday.Thursday,
+        DayOfWeek.Friday => Weekday.Friday,
+        DayOfWeek.Saturday => Weekday.Saturday,
+        DayOfWeek.Sunday => Weekday.Sunday,
+        _ => throw new ArgumentOutOfRangeException(),
+    };
+
+    public DayOfWeek ToDayOfWeek() => Value switch
+    {
+        MONDAY => DayOfWeek.Monday,
+        TUESDAY => DayOfWeek.Tuesday,
+        WEDNESDAY => DayOfWeek.Wednesday,
+        THURSDAY => DayOfWeek.Thursday,
+        FRIDAY => DayOfWeek.Friday,
+        SATURDAY => DayOfWeek.Saturday,
+        SUNDAY => DayOfWeek.Sunday,
+        _ => throw new ArgumentOutOfRangeException(),
+    };
+    
     public static bool operator ==(Weekday? left, Weekday? right)
     {
         return EqualOperator(left, right);
@@ -40,61 +94,6 @@ public class Weekday : Equatable
     public static bool operator !=(Weekday? left, Weekday? right)
     {
         return NotEqualOperator(left, right);
-    }
-
-    public Weekday Next()
-    {
-        return Add(1);
-    }
-
-    public Weekday Previous()
-    {
-        return Add(-1);
-    }
-
-    public Weekday Add(int days)
-    {
-        var currentOrderIndex = Array.IndexOf(ORDERED_VALUES, this);
-        var nextOrderIndex = (currentOrderIndex + days) % ORDERED_VALUES.Length;
-        nextOrderIndex = nextOrderIndex < 0 ? ORDERED_VALUES.Length + nextOrderIndex : nextOrderIndex;
-        return ORDERED_VALUES.ElementAt(nextOrderIndex);
-    }
-
-    private static readonly IDictionary<Weekday, DayOfWeek> DAY_OF_WEEKS = new Dictionary<Weekday, DayOfWeek>
-    {
-        [Sunday] = DayOfWeek.Sunday,
-        [Monday] = DayOfWeek.Monday,
-        [Tuesday] = DayOfWeek.Tuesday,
-        [Wednesday] = DayOfWeek.Wednesday,
-        [Thursday] = DayOfWeek.Thursday,
-        [Friday] = DayOfWeek.Friday,
-        [Saturday] = DayOfWeek.Saturday,
-    };
-
-    public static Weekday From(DayOfWeek dayOfWeek)
-    {
-        return new Weekday(DAY_OF_WEEKS.First(x => x.Value == dayOfWeek).Key.Value);
-    }
-
-    public DayOfWeek ToDayOfWeek()
-    {
-        return DAY_OF_WEEKS[this];
-    }
-
-    private static readonly IDictionary<Weekday, IsoDayOfWeek> ISO_DAY_OF_WEEKS = new Dictionary<Weekday, IsoDayOfWeek>
-    {
-        [Monday] = IsoDayOfWeek.Monday,
-        [Tuesday] = IsoDayOfWeek.Tuesday,
-        [Wednesday] = IsoDayOfWeek.Wednesday,
-        [Thursday] = IsoDayOfWeek.Thursday,
-        [Friday] = IsoDayOfWeek.Friday,
-        [Saturday] = IsoDayOfWeek.Saturday,
-        [Sunday] = IsoDayOfWeek.Sunday,
-    };
-
-    internal IsoDayOfWeek ToIsoDayOfWeek()
-    {
-        return ISO_DAY_OF_WEEKS[this];
     }
 
     protected override IEnumerable<object?> GetEqualityComponents()

--- a/src/Webinex.Calendar/DataAccess/EventRow.cs
+++ b/src/Webinex.Calendar/DataAccess/EventRow.cs
@@ -53,7 +53,7 @@ public class EventRow<TData>
 
     [MemberNotNullWhen(true, nameof(RecurrentEventId))]
     internal bool IsRecurrentEventState() => Type == EventType.RecurrentEventState;
-    
+
     internal EventRow<TData>? RecurrentEvent { get; set; }
 
     internal EventRowId GetEventRowId() => new EventRowId(Type, Id, RecurrentEventId, Effective.ToOpenPeriod().Start);
@@ -198,32 +198,21 @@ public class EventRow<TData>
         var max = period.End.TotalMinutesSince1990();
 
         return (Effective.Start < max && (!Effective.End.HasValue || Effective.End.Value > min))
-                    || (MoveTo != null && MoveTo!.Start < period.End && MoveTo.End > period.Start);
+               || (MoveTo != null && MoveTo!.Start < period.End && MoveTo.End > period.Start);
     }
 
-    internal static Expression<Func<EventRow<TData>, bool>> Selector(Weekday weekday)
-    {
-        if (weekday == Weekday.Monday)
-            return x => x.Repeat!.Monday!.Value;
+    internal static Expression<Func<EventRow<TData>, bool>> WeekdaySelector(Weekday weekday) =>
+        WeekdaySelectorMap[weekday];
 
-        if (weekday == Weekday.Tuesday)
-            return x => x.Repeat!.Tuesday!.Value;
-
-        if (weekday == Weekday.Wednesday)
-            return x => x.Repeat!.Wednesday!.Value;
-
-        if (weekday == Weekday.Thursday)
-            return x => x.Repeat!.Thursday!.Value;
-
-        if (weekday == Weekday.Friday)
-            return x => x.Repeat!.Friday!.Value;
-
-        if (weekday == Weekday.Saturday)
-            return x => x.Repeat!.Saturday!.Value;
-
-        if (weekday == Weekday.Sunday)
-            return x => x.Repeat!.Sunday!.Value;
-
-        throw new InvalidOperationException();
-    }
+    private static IReadOnlyDictionary<Weekday, Expression<Func<EventRow<TData>, bool>>> WeekdaySelectorMap =
+        new Dictionary<Weekday, Expression<Func<EventRow<TData>, bool>>>
+        {
+            [Weekday.Monday] = x => x.Repeat!.Monday!.Value,
+            [Weekday.Tuesday] = x => x.Repeat!.Tuesday!.Value,
+            [Weekday.Wednesday] = x => x.Repeat!.Wednesday!.Value,
+            [Weekday.Thursday] = x => x.Repeat!.Thursday!.Value,
+            [Weekday.Friday] = x => x.Repeat!.Friday!.Value,
+            [Weekday.Saturday] = x => x.Repeat!.Saturday!.Value,
+            [Weekday.Sunday] = x => x.Repeat!.Sunday!.Value
+        };
 }


### PR DESCRIPTION
- skipped redundant checks for weekdays, when period includes all weekdays (see MatchWeekdayEventFilterFactory 37 line) => sql query is simplified
- removed redundant memory allocations + optimized some algorithms 

MatchWeekdayEventFilterFactory.Create with different periods.
Memory allocation is still significant due to the use of expressions, but 2x less than before
![image](https://github.com/user-attachments/assets/af013e42-ea82-4556-bebc-8e275a50770d)
