### PR TITLE
Fix null reference exception

### DIFF
--- a/src/Webinex.Calendar.All/Package.props
+++ b/src/Webinex.Calendar.All/Package.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <Title>Webinex Calendar</Title>
-    <PackageVersion>2.0.0-build2</PackageVersion>
+    <PackageVersion>2.0.0-build3</PackageVersion>
     <Authors>Webinex Dev</Authors>
     <NoWarn>$(NoWarn);CS1591;CS0660;CS0661</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Webinex.Calendar/Calculators/OccurrenceCalculator.cs
+++ b/src/Webinex.Calendar/Calculators/OccurrenceCalculator.cs
@@ -101,7 +101,7 @@ public class OccurrenceCalculator<TData>
         Event<TData> @event,
         Occurrence<TData>[] occurrences)
     {
-        foreach (var adjustment in _adjustments.Where(x => x.RecurrentEventId == @event.Id && !x.Cancelled))
+        foreach (var adjustment in _adjustments.Where(x => x.RecurrentEventId == @event.Id && !x.Cancelled && x.MoveTo != null))
         {
             if (occurrences.Any(x => x.Id == adjustment.Id))
                 continue;


### PR DESCRIPTION
The issue occurred when one of the adjustments for a recurrent event had MoveTo set to null.

According to the existing logic, if adjustments fall within the period, they are added in the step above in the CalculateRecurrentEventOccurrences method.
If not, the adjustment is treated as being outside the period. However, it could be moved into the period, and in that case MoveTo must not be null.